### PR TITLE
Add support for selecting by custom attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ var language = require("cssauron")({
   contents: "contents",
   attr: function(node, attr) {
     if (node.properties) {
+      var attrs = node.properties.attributes
+      if(attrs && attrs[attr]){
+        return attrs[attr];
+      }
       return node.properties[attr];
     }
   },

--- a/test.js
+++ b/test.js
@@ -7,6 +7,8 @@ var span1 = h("span.span1", "hello world");
 var span2 = h("span.span2", "hello world2");
 var li = h("li", "item");
 var ul = h("ul", [li]);
+var props = h("div", { label : 'label' });
+var attrs = h("div", { attributes : {'custom-attr' : 'custom'} });
 var tree = h("div#tree", [span1, span2, ul]);
 
 var assert = require("assert");
@@ -18,6 +20,10 @@ assert.deepEqual(select("#tree")(tree), [tree]);
 assert.deepEqual(select("[id]")(tree), [tree]);
 assert.deepEqual(select("[id=tree]")(tree), [tree]);
 assert.deepEqual(select("div[id=tree]")(tree), [tree]);
+
+// properties/attributes
+assert.deepEqual(select('[label]')(props),[props]);
+assert.deepEqual(select('[custom-attr]')(attrs),[attrs]);
 
 // Select children
 assert.deepEqual(select("span")(tree), [span1, span2]);


### PR DESCRIPTION
Custom attributes in virtual-dom are set on the properties.attributes object, and so wouldn't be matched without this fix.
Also added tests to demonstrate the previous failure case.