### PR TITLE
test if vtree matches selector without traversing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ var vtree = h("div", [
 
 select("div strong")(vtree)
 // -> <strong>world</strong> (VNode object)
+
+select("div strong").matches(vtree)
+// -> false
+
+select("div").matches(vtree)
+// -> true
 ```
 
 ## API
@@ -40,6 +46,11 @@ Unlike css and `querySelectorAll`, *text nodes* are matched and
 returned.
 
 Selectors are **case-sensitive**.
+
+### `match.matches(vtree) -> boolean`
+
+Returns `true` if the vtree matches the selector, or `false` otherwise.
+
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ var language = require("cssauron")({
 
 module.exports = function(sel) {
   var selector = language(sel);
-  return function(vtree) {
+  function match(vtree) {
     var node = mapTree(vtree);
     var matched = [];
 
@@ -42,6 +42,10 @@ module.exports = function(sel) {
     }
     return mapResult(matched);
   };
+  match.matches = function(vtree) {
+    return !!selector(vtree);
+  }
+  return match;
 };
 
 function traverse(vtree, fn) {

--- a/test.js
+++ b/test.js
@@ -34,3 +34,10 @@ assert.deepEqual(select("*:root")(tree), [tree]);
 
 // :contains() pseudo
 assert.deepEqual(select("!* > :contains('hello')")(tree), [span1, span2]);
+
+// matches(vtree)
+assert.strictEqual(select("*:root#tree").matches(tree), true);
+assert.strictEqual(select("span.span1").matches(tree.children[0]), true);
+assert.strictEqual(select("zz").matches(tree), false);
+assert.strictEqual(select(":not(span)").matches(tree), true);
+assert.strictEqual(select(":not(div)").matches(tree), false);


### PR DESCRIPTION
Adds the ability to test whether a virtual-dom node matches a selector.