### PR TITLE
Ignores vtree type VirtualComment.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function mapResult(result) {
 }
 
 function mapTree(vtree, parent) {
-  if (vtree.type === "VirtualText" || vtree.type ==="VirtualComment") {
+  if (vtree.type === "VirtualText" || vtree.type === "Widget") {
     return {
       contents: vtree.text,
       properties: {},

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function mapResult(result) {
 }
 
 function mapTree(vtree, parent) {
-  if (vtree.type === "VirtualText") {
+  if (vtree.type === "VirtualText" || vtree.type ==="VirtualComment") {
     return {
       contents: vtree.text,
       properties: {},


### PR DESCRIPTION
VirtualComment was added to virtual-dom on October 2. mapTree needs to
ignore this type to avoid throwing a TypeError.