### PR TITLE
Fix `matches` bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,8 +47,7 @@ module.exports = function(sel, options) {
     return results;
   }
   match.matches = function(vtree) {
-    var node = mapTree(vtree, null, options);
-    return !!selector(node);
+    return match(vtree) !== null;
   };
   return match;
 };

--- a/test.js
+++ b/test.js
@@ -46,6 +46,10 @@ assert.strictEqual(select("span.span1").matches(tree.children[0]), true);
 assert.strictEqual(select("zz").matches(tree), false);
 assert.strictEqual(select(":not(span)").matches(tree), true);
 assert.strictEqual(select(":not(div)").matches(tree), true);
+// matches(vtree) select children
+assert.strictEqual(select("span").matches(tree), true);
+assert.strictEqual(select("span.span1").matches(tree), true);
+assert.strictEqual(select("span.span2").matches(tree), true);
 
 // Widget
 // Use widget from virtual-dom example

--- a/test.js
+++ b/test.js
@@ -43,6 +43,7 @@ assert.deepEqual(select("!* > :contains('hello')")(tree), [span1, span2]);
 // matches(vtree)
 assert.strictEqual(select("*:root#tree").matches(tree), true);
 assert.strictEqual(select("span.span1").matches(tree.children[0]), true);
+assert.strictEqual(select("div").matches(tree.children[0]), false);
 assert.strictEqual(select("zz").matches(tree), false);
 assert.strictEqual(select(":not(span)").matches(tree), true);
 assert.strictEqual(select(":not(div)").matches(tree), true);

--- a/test.js
+++ b/test.js
@@ -45,7 +45,7 @@ assert.strictEqual(select("*:root#tree").matches(tree), true);
 assert.strictEqual(select("span.span1").matches(tree.children[0]), true);
 assert.strictEqual(select("zz").matches(tree), false);
 assert.strictEqual(select(":not(span)").matches(tree), true);
-assert.strictEqual(select(":not(div)").matches(tree), false);
+assert.strictEqual(select(":not(div)").matches(tree), true);
 
 // Widget
 // Use widget from virtual-dom example


### PR DESCRIPTION
`match.matches` doesn't match against children. Is it bug?

I think that `traverse` must be called in `matches`.

See commits.